### PR TITLE
Subtract some seconds from getTimestamp

### DIFF
--- a/src/utils/chainweb.js
+++ b/src/utils/chainweb.js
@@ -1,7 +1,7 @@
 import Pact from 'pact-lang-api';
 import lib from 'cardano-crypto.js/kadena-crypto';
 import { CONFIG } from './config';
-import { creationTime } from './index';
+import { getTimestamp } from './index';
 
 export const getApiUrl = (url, networkId, chainId) => `${url}/chainweb/0.0/${networkId}/chain/${chainId}/pact`;
 
@@ -9,7 +9,7 @@ export const fetchLocal = (code, url, networkId, chainId) => {
   const localCmd = {
     keyPairs: [],
     pactCode: code,
-    meta: Pact.lang.mkMeta('not-real', chainId.toString(), 0.00000001, 6000, creationTime(), 600),
+    meta: Pact.lang.mkMeta('not-real', chainId.toString(), 0.00000001, 6000, getTimestamp(), 600),
   };
   return Pact.fetch.local(localCmd, getApiUrl(url, networkId, chainId));
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { KNOWN_TOKENS } from './constant';
 
-export const getTimestamp = () => Math.floor(new Date().getTime() / 1000);
+export const getTimestamp = () => Math.floor(new Date().getTime() / 1000) - 90;
 
 export const createBlob = (str, mime) => {
   const string = typeof str === 'object' ? JSON.stringify(str) : str;
@@ -64,8 +64,6 @@ export const convertRecent = (data) => {
   });
   return recent;
 };
-
-export const creationTime = () => Math.round(new Date().getTime() / 1000) - 15;
 
 export const shortenAddress = (address = '', start = 5, chars = 5) =>
   address.length > 14 ? `${address.substring(0, start)} ... ${address.substring(address.length - chars)}` : address;


### PR DESCRIPTION
If the `creationTime` is off by a few seconds (if the clock is out of sync), the transaction fails to send (chainweb is really strict about this). We should subtract some amount of time from this to work around this. Here I went with 90 seconds of leeway just in case.

This also removes the `creationTime` function from `utils/index.js` since it was basically duplicated from `getTimestamp`.