### PR TITLE
Attempt to fix crosschain out of gas issues

### DIFF
--- a/src/contexts/CrossChainContext.tsx
+++ b/src/contexts/CrossChainContext.tsx
@@ -143,7 +143,7 @@ export const CrossChainProvider = ({ children }: any) => {
         const proof = res;
         const pactId = requestKey.length === 44 ? requestKey.slice(0, 43) : requestKey;
         const host = getApiUrl(selectedNetwork.url, selectedNetwork.networkId, targetChainId);
-        const gasStation = 'free-x-chain-gas';
+        const gasStation = CONFIG.X_CHAIN_GAS_STATION;
         const m = Pact.lang.mkMeta(gasStation, targetChainId, CONFIG.X_CHAIN_GAS_PRICE, CONFIG.X_CHAIN_GAS_LIMIT, getTimestamp(), CONFIG.X_CHAIN_TTL);
         const cmd = {
           type: 'cont',

--- a/src/pages/GenerateAccount/index.tsx
+++ b/src/pages/GenerateAccount/index.tsx
@@ -112,7 +112,7 @@ const GenerateAccount = () => {
         k: [publicKey],
       },
       meta: Pact.lang.mkMeta(
-        'free-x-chain-gas',
+        CONFIG.X_CHAIN_GAS_STATION,
         chainIdValue.toString(),
         CONFIG.X_CHAIN_GAS_PRICE,
         CONFIG.X_CHAIN_GAS_LIMIT,

--- a/src/pages/Wallet/views/ChainDropdown.tsx
+++ b/src/pages/Wallet/views/ChainDropdown.tsx
@@ -201,7 +201,7 @@ const ChainDropdown = () => {
   //       k: [publicKey],
   //     },
   //     meta: Pact.lang.mkMeta(
-  //       'free-x-chain-gas',
+  //       CONFIG.X_CHAIN_GAS_STATION,
   //       chainId.toString(),
   //       CONFIG.X_CHAIN_GAS_PRICE,
   //       CONFIG.X_CHAIN_GAS_LIMIT,

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,5 +1,6 @@
+const X_CHAIN_GAS_STATION = 'kadena-xchain-gas';
 const X_CHAIN_GAS_PRICE = 0.00000001;
-const X_CHAIN_GAS_LIMIT = 400;
+const X_CHAIN_GAS_LIMIT = 750;
 const X_CHAIN_TTL = 28800;
 
 const GAS_PRICE = 0.000001;


### PR DESCRIPTION
Due to the newly released 2.16 chainweb version, gas usage was fixed and increased among a few common operations like token transfers.

This affected crosschains, and the 2nd half of crosschains now take more gas than before.

The `free-x-chain-gas` gas station only allows gas limits up to 400, but the `kadena-xchain-gas` gas station allows gas limits up to 750 (you can get this information from `(coin.details "kadena-xchain-gas")`). This PR changes the config to use the new gas station and gas limit.

Caveat: This seems to be enough to correctly perform crosschains of `coin`, but looking at the explorer, crosschains for other tokens use more than 750 gas (I've seen a few transactions for fungible-v2 tokens that are using 800-820 gas for the 2nd half). I'm not sure how we can deal with that, since those would probably still fail even with this change, so this PR might not be a permanent and complete fix. (we might need another gas station? not sure -- we need to test with other tokens)