### PR TITLE
Fixed signing cmd fields

### DIFF
--- a/src/pages/Dapps/SignedCmd.tsx
+++ b/src/pages/Dapps/SignedCmd.tsx
@@ -156,7 +156,7 @@ const SignedCmd = () => {
         const signedCmd = Pact.api.prepareExecCmd(
           keyPairs,
           `${ECKO_WALLET_DAPP_SIGN_NONCE}-"${new Date().toISOString()}"`,
-          signingCmd?.pactCode || signingCmd?.pactCode,
+          signingCmd?.pactCode || signingCmd?.code,
           signingCmd?.data || signingCmd?.envData,
           meta,
           signingCmd.networkId,

--- a/src/pages/Dapps/SignedCmd.tsx
+++ b/src/pages/Dapps/SignedCmd.tsx
@@ -156,8 +156,8 @@ const SignedCmd = () => {
         const signedCmd = Pact.api.prepareExecCmd(
           keyPairs,
           `${ECKO_WALLET_DAPP_SIGN_NONCE}-"${new Date().toISOString()}"`,
-          signingCmd?.pactCode || signingCmd?.code,
-          signingCmd.envData,
+          signingCmd?.pactCode || signingCmd?.pactCode,
+          signingCmd?.data || signingCmd?.envData,
           meta,
           signingCmd.networkId,
         );


### PR DESCRIPTION
Fixed signing command fields.
According to [ISigningRequest](https://github.com/kadena-community/kadena.js/blob/7d06bd2d9b4a0e0172983bc48d1ae2f86b51120d/packages/libs/client/src/interfaces/ISigningRequest.ts#L6) interface field should be called **data**, not **envData**.
Also, data field is used in kadena.js client lib to process transaction data before submitting ([pactCommandToSigningRequest](https://github.com/kadena-community/kadena.js/blob/7d06bd2d9b4a0e0172983bc48d1ae2f86b51120d/packages/libs/client/src/signing/utils/pactCommandToSigningRequest.ts#L14))
"code" and "data" fields are used in [pact exec request](https://github.com/kadena-io/pact/blob/master/templates/exec-request-template.yaml)